### PR TITLE
explicitly set default_auto_field

### DIFF
--- a/planty_content/apps.py
+++ b/planty_content/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class PlantyContentConfig(AppConfig):
     name = "planty_content"
     verbose_name = "Reben"
+    default_auto_field = "django.db.models.AutoField"

--- a/planty_plant_content/apps.py
+++ b/planty_plant_content/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class PlantyPlantContentConfig(AppConfig):
     name = "planty_plant_content"
     verbose_name = "Kulturpflanzen"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
After Django 3.2 not explicitly set primary keys can be of type AutoField (like they used to be) or the new BigAutoField. This pull request configures them as being of type AutoField to avoid problems in the future and get rid of warnings. See issue no. 188 in solid-backend.